### PR TITLE
Add Flask-WTF to requiremenents

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Flask-Login==0.4.0
 Flask-Migrate==1.8.0
 Flask-Script==2.0.5
 Flask-SQLAlchemy==2.1
+Flask-WTF==0.14.2
 itsdangerous==0.24
 Jinja2==2.9.5
 Mako==1.0.6


### PR DESCRIPTION
Now there is imports of flask-wtf package in
ui/forms.py file, but there isn't this package
in requirements.